### PR TITLE
feat: support startup reveal/focus by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,13 @@ make install  # installs to /usr/local/bin/bontree
 ## Usage
 
 ```bash
-bontree [path]
+bontree [path] [focus-path]
 ```
 
 Defaults to the current directory if no path is given.
+
+- If `path` is a file, bontree opens its parent directory and focuses that file.
+- `focus-path` can be absolute or relative to `path`.
 
 ## Keybindings
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/ui/update.go
+++ b/ui/update.go
@@ -31,6 +31,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.ensureVisible()
 		return m, nil
 
 	case clearFlashMsg:


### PR DESCRIPTION
note: based on #2 

## Summary
- Add startup path resolution so `bontree` accepts directory, file, or explicit focus path forms
- Introduce `ui.NewWithFocus` to reveal/focus a target by absolute or relative path by expanding ancestor directories
- Fix initial viewport scroll behavior so focused items don't render from a cut-off top when terminal size is not known yet
- Document updated usage with optional `focus-path`

## Testing
- go test ./ui ./config ./theme ./tree ./icons .

## sample integration with kakoune


https://github.com/user-attachments/assets/0e61008b-32fd-4e2a-abfd-058c9cbed8b8


